### PR TITLE
fix: trim Luna defaultPrompt under Codex's 128-char cap

### DIFF
--- a/plugins/sol-advisor/.codex-plugin/plugin.json
+++ b/plugins/sol-advisor/.codex-plugin/plugin.json
@@ -16,6 +16,6 @@
     "category": "Productivity",
     "capabilities": ["Interactive", "Write"],
     "websiteURL": "https://github.com/DannyMac180/sol-advisor",
-    "defaultPrompt": ["Use Sol Advisor's native lane to build this feature, verify it, and obtain the fresh Sol review before completion.", "Use the Luna task lane only when I explicitly authorize it; create user-visible GPT-5.6 Luna / Max tasks through Codex app task tools and keep primary review and acceptance in this task."]
+    "defaultPrompt": ["Use Sol Advisor's native lane to build this feature, verify it, and obtain the fresh Sol review before completion.", "Use the Luna task lane only when I explicitly authorize it; keep primary review and acceptance in this task."]
   }
 }


### PR DESCRIPTION
Codex caps each `interface.defaultPrompt` entry at **128 characters** and silently truncates longer ones. The second entry in `plugins/sol-advisor/.codex-plugin/plugin.json` is **186 chars**, so it's currently cut mid-sentence around *"…and keep primary review and"*.

This trims it to 107 chars:

```diff
-"Use the Luna task lane only when I explicitly authorize it; create user-visible GPT-5.6 Luna / Max tasks through Codex app task tools and keep primary review and acceptance in this task."
+"Use the Luna task lane only when I explicitly authorize it; keep primary review and acceptance in this task."
```

The dropped "…through Codex app task tools" detail is already covered in `SKILL.md` and the README, so no information is lost — the starter prompt just no longer truncates. Both `defaultPrompt` entries are now ≤128 (114 and 108).

Found while auditing the plugin's NL artifacts; everything else checked clean (the TOML agents, the install script's hygiene, and the skill all looked solid).
