### PR TITLE
Fix verifier manifest assertion and add CI

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,0 +1,36 @@
+name: Verify
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    name: Verify (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Run repository verifier
+        run: sh plugins/sol-advisor/scripts/verify.sh
+
+      - name: Check patch whitespace
+        run: git diff --check

--- a/plugins/sol-advisor/.codex-plugin/plugin.json
+++ b/plugins/sol-advisor/.codex-plugin/plugin.json
@@ -11,7 +11,7 @@
   "interface": {
     "displayName": "Sol Advisor",
     "shortDescription": "Orchestrate with Sol, use native Terra / High or opt-in Luna tasks, and verify the accepted diff.",
-    "longDescription": "Sol Advisor gives Codex two explicit delivery modes: GPT-5.6 Sol keeps architecture, decomposition, verification, and acceptance in the primary session; the native mode uses a separately installed GPT-5.6 Terra / High role and a fresh Sol reviewer, while the opt-in Luna mode creates user-visible GPT-5.6 Luna / Max tasks through list_projects, list_threads, create_thread, wait_threads, read_thread, and send_message_to_thread and keeps review, corrections, PR authorization, and dependent-stack ordering in the primary session.",
+    "longDescription": "Sol Advisor gives Codex two explicit delivery modes: GPT-5.6 Sol keeps architecture, decomposition, verification, and acceptance in the primary session; the native mode uses a separately installed GPT-5.6 Terra / High role and a fresh Sol reviewer, while the opt-in Luna mode creates user-visible GPT-5.6 Luna / Max tasks through Codex app task tools such as list_projects, list_threads, create_thread, wait_threads, read_thread, and send_message_to_thread and keeps review, corrections, PR authorization, and dependent-stack ordering in the primary session.",
     "developerName": "Daniel McAteer",
     "category": "Productivity",
     "capabilities": ["Interactive", "Write"],


### PR DESCRIPTION
## What changed

- Describe the opt-in Luna lane as using Codex app task tools so the plugin manifest satisfies the repository verifier's routing guard.
- Add GitHub Actions coverage on Ubuntu and macOS with Python 3.11.
- Run the repository verifier and `git diff --check` for pushes to `main` and pull requests.

## Why

The documented verifier currently fails on `main` before reaching its behavioral checks because it requires the manifest to contain the exact `Codex app task tools` routing description, while the manifest only lists the individual tool names. The repository also has no automated workflow to catch this kind of drift.

## Impact

This does not change runtime routing or agent behavior. It aligns user-facing plugin metadata with the existing contract and makes the repository's own verification portable and automatic.

## Validation

- `sh plugins/sol-advisor/scripts/verify.sh` with Python 3.11: passed
- `git diff --check`: passed
