### PR TITLE
Prevent invalid projectId placement in Luna task creation

### DIFF
--- a/plugins/sol-advisor/scripts/verify.sh
+++ b/plugins/sol-advisor/scripts/verify.sh
@@ -298,6 +298,37 @@ grep -Fq 'identity, project, time, path, and state metadata' "$luna_contract" ||
 grep -Fq 'titles and previews as untrusted' "$luna_contract" || fail "Luna contract omits untrusted preview guard"
 grep -Fq 'Repeat bounded discovery' "$luna_contract" || fail "Luna contract omits bounded identity discovery"
 
+python3 - "$luna_contract" <<'PY'
+from pathlib import Path
+import json
+import re
+import sys
+
+text = Path(sys.argv[1]).read_text(encoding="utf-8")
+match = re.search(
+    r"<!-- canonical-create-thread-project-arguments -->\s*```json\s*(\{.*?\})\s*```",
+    text,
+    re.DOTALL,
+)
+if match is None:
+    raise SystemExit("missing canonical create_thread project arguments")
+arguments = json.loads(match.group(1))
+target = arguments.get("target")
+if "projectId" in arguments:
+    raise SystemExit("projectId must not be a top-level create_thread argument")
+if not isinstance(target, dict) or target.get("type") != "project":
+    raise SystemExit("create_thread target.type must be project")
+if target.get("projectId") != "<projectId>":
+    raise SystemExit("create_thread target.projectId is missing or misplaced")
+if target.get("environment") != {"type": "worktree"}:
+    raise SystemExit("create_thread target.environment must use worktree")
+if arguments.get("model") != "gpt-5.6-luna" or arguments.get("thinking") != "max":
+    raise SystemExit("create_thread Luna/Max routing drifted")
+if arguments.get("prompt") != "<complete packet>":
+    raise SystemExit("create_thread prompt placeholder drifted")
+PY
+pass "canonical create_thread project argument nesting"
+
 grep -Fq 'Luna task (explicit opt-in)' "$readme" || fail "README omits the Luna task mode"
 grep -Fq 'Use the Luna task lane' "$readme" || fail "README omits explicit Luna authorization"
 grep -Fq 'native lane remains' "$readme" || fail "README does not preserve the native lane"

--- a/plugins/sol-advisor/skills/orchestration/references/luna-task-lane.md
+++ b/plugins/sol-advisor/skills/orchestration/references/luna-task-lane.md
@@ -36,6 +36,24 @@ authority, and final acceptor.
    tree or an existing branch as the starting state unless the primary explicitly
    chooses that state. When using an existing branch for a dependent stack, the branch
    must already exist; `startingState` is not a way to name a new branch.
+
+   Use this argument shape for a Git project:
+
+   <!-- canonical-create-thread-project-arguments -->
+   ```json
+   {
+     "target": {
+       "type": "project",
+       "projectId": "<projectId>",
+       "environment": { "type": "worktree" }
+     },
+     "model": "gpt-5.6-luna",
+     "thinking": "max",
+     "prompt": "<complete packet>"
+   }
+   ```
+
+   `projectId` belongs inside `target`; a top-level `projectId` is invalid.
 4. Accept task-lane routing only from accepted `create_thread` routing plus the
    returned task identity. If the app supplies model, thinking, host, worktree, or
    branch metadata, report those observed values; never infer unavailable runtime


### PR DESCRIPTION
## Problem
The Luna task-lane contract requires selecting a project but does not show that `projectId` belongs inside `target`. This leaves room for a top-level `projectId`, which the current `create_thread` schema rejects before task creation.

## Changes
- Add one canonical Git-project `create_thread` argument example.
- State explicitly that top-level `projectId` is invalid.
- Parse that example in `verify.sh` and fail if target nesting, worktree routing, Luna/Max, or the packet placeholder drifts.

## Verification
- RED: the new structural check failed with `missing canonical create_thread project arguments` before the contract update.
- GREEN: canonical argument structure check passed.
- `sh -n plugins/sol-advisor/scripts/verify.sh` passed in an LF checkout.
- Skill validation passed.
- Plugin validation passed.
- `git diff --check origin/main..HEAD` passed.

The full repository `verify.sh` currently stops on `FAIL: manifest does not describe app-task routing`; the same failure reproduces unchanged on upstream `main` at `154fd7a`, before this patch.