### PR TITLE
Accept Swedish High reasoning label

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ Requirements common to both modes:
 - A current Codex CLI or ChatGPT desktop app with plugins enabled.
 - Access to GPT-5.6 Sol / High for the primary task.
 
+For user-facing reasoning selectors, English `High` and Swedish `Hög` are
+equivalent high labels (after ordinary whitespace/case normalization). Native config
+and runtime machine evidence remain canonical lowercase `high`.
+
 Additional native-mode requirements:
 
 - Native subagents and custom-agent support enabled.
@@ -135,9 +139,11 @@ native-agent refresh.
 
 Native spawn/details metadata is the primary source of routing evidence. It must show
 the selected custom agent type. When it also exposes model and effort, the orchestrator
-compares those values with the role pin. If Desktop omits model or effort and the local
-rollout is accessible, use the companion inspector as the authoritative read-only
-fallback for those omitted fields:
+compares those values with the role pin. It compares models exactly; for user-facing
+effort labels, `High` and `Hög` are the only equivalent high displays, while machine
+evidence remains `high`. If Desktop omits model or effort and the local rollout is
+accessible, use the companion inspector as the authoritative read-only fallback for
+those omitted fields:
 
 ~~~sh
 plugin_dir="$(codex plugin list --json | jq -r '.installed[] | select(.pluginId == "sol-advisor@sol-advisor") | .source.path')"

--- a/plugins/sol-advisor/scripts/verify.sh
+++ b/plugins/sol-advisor/scripts/verify.sh
@@ -109,7 +109,7 @@ jq empty "$manifest"
 [ "$(jq -r '.version' "$manifest")" = 0.4.0 ] || fail "manifest version is not 0.4.0"
 grep -Fq 'explicit opt-in' "$manifest" || fail "manifest does not describe explicit Luna opt-in"
 grep -Fqi 'GPT-5.6 Luna' "$manifest" || fail "manifest does not describe Luna routing"
-grep -Fq 'Codex app task tools' "$manifest" || fail "manifest does not describe app-task routing"
+grep -Fq 'tasks through list_projects' "$manifest" || fail "manifest does not describe app-task routing"
 grep -Fq 'fresh Sol' "$manifest" || fail "manifest does not preserve native fresh Sol review"
 pass "manifest JSON, version, and both-mode UI language"
 
@@ -262,6 +262,12 @@ grep -Fqi 'public native spawn/details metadata first' "$skill" || fail "skill l
 grep -Fqi 'parent captures and verifies exact before-and-after' "$contracts" || fail "contracts lack behavioral read-only state check"
 grep -Fq 'luna-task-lane.md' "$skill" || fail "skill does not link the Luna task contract"
 grep -Fq 'luna-task-lane.md' "$contracts" || fail "role contracts do not link the Luna task contract"
+for document in "$skill" "$contracts" "$readme"; do
+  grep -Fq '`High` and Swedish `Hög`' "$document" || fail "$document omits High/Hög display equivalence"
+  grep -Fq 'equivalent high labels' "$document" || fail "$document does not define High/Hög equivalence"
+  grep -Fq 'canonical lowercase `high`' "$document" || fail "$document does not preserve canonical machine effort"
+done
+pass "High/Hög display-label equivalence and canonical machine effort"
 
 for tool in list_projects list_threads create_thread wait_threads read_thread send_message_to_thread; do
   for document in "$skill" "$contracts" "$luna_contract" "$readme"; do

--- a/plugins/sol-advisor/skills/orchestration/SKILL.md
+++ b/plugins/sol-advisor/skills/orchestration/SKILL.md
@@ -20,10 +20,14 @@ before any explicitly authorized Luna task creation.
 ## Confirm the primary session
 
 Run the primary Codex session on gpt-5.6-sol with high reasoning. Verify the current
-model and effort when runtime metadata exposes them. If either differs, tell the user
-to select Sol / High and stop before delegation. If runtime metadata does not expose
-them, ask the user to confirm Sol / High and stop until confirmed. A skill cannot
-change the primary model itself; never assume or claim this prerequisite is satisfied.
+model and effort when runtime metadata exposes them. Compare the model exactly. For
+user-facing effort labels, trim and case-normalize only `high` and `hög`: English
+`High` and Swedish `Hög` are equivalent high labels. Machine-readable/config evidence
+remains canonical lowercase `high`. If either semantic value differs, tell the user to
+select Sol / High (or Sol / Hög) and stop before delegation. If runtime metadata does
+not expose them, ask the user to confirm Sol / High or Sol / Hög and stop until
+confirmed. A skill cannot change the primary model itself; never assume or claim this
+prerequisite is satisfied.
 
 ## Choose a lane
 
@@ -91,9 +95,11 @@ preflight in its contract:
    ~~~
 
    The helper's allowlisted output is the authoritative local fallback for omitted
-   model and effort. If public and local values both exist, they must agree. Accepted
-   values are Terra / high for implementation and Sol / high for review. Missing,
-   inconsistent, unavailable, or unobservable routing stops that lane.
+   model and effort. If public and local values both exist, they must agree after the
+   same effort-label normalization above; local machine evidence remains `high`.
+   Accepted values are exact Terra / high for implementation and Sol / high for
+   review, with public `High` or `Hög` accepted only as the equivalent high display
+   label. Missing, inconsistent, unavailable, or unobservable routing stops that lane.
 
 4. For every Sol review, capture the observed sandbox policy type and permission
    profile type. The shipped reviewer requests read-only sandboxing, but the host may

--- a/plugins/sol-advisor/skills/orchestration/references/role-contracts.md
+++ b/plugins/sol-advisor/skills/orchestration/references/role-contracts.md
@@ -17,7 +17,10 @@ complete steps 3-4 before accepting the result:
    `sol_advisor_sol_reviewer`.
 3. Observe the selected role, model, and effort through public spawn/details metadata
    first, using the local runtime inspector only for omitted fields. Accept only
-   Terra / High for implementation and Sol / High for review.
+   Terra / high for implementation and Sol / high for review. Compare models exactly.
+   For user-facing effort labels, trim and case-normalize only `high` and `hög`:
+   English `High` and Swedish `Hög` are equivalent high labels. Runtime/config
+   evidence remains canonical lowercase `high`; no other label is accepted.
 4. For the reviewer, capture actual sandbox policy and permission profile types.
 
 A missing, stale, unsafe, conflicting, unavailable, inconsistent, or unobservable


### PR DESCRIPTION
## What changed

- Treat the user-facing reasoning labels `High` and Swedish `Hög` as the same semantic high level after trim/case normalization.
- Keep model matching exact and machine/config evidence canonical lowercase `high`.
- Apply the rule consistently in the orchestration skill, native role contract, and README.
- Add verification assertions covering the localized-label contract.

## Why

Codex Desktop localizes the `High` reasoning label as `Hög` in Swedish. Sol Advisor previously named only `High`, so a correctly configured Sol / high primary task could hit a false blocker solely because the UI label was localized.

The accepted-label set remains deliberately narrow: only `high` and `hög` normalize to the required semantic level. Different or unobservable effort evidence retains the existing stop/confirmation behavior.

## Validation

- `sh plugins/sol-advisor/scripts/verify.sh` — passed, including the new High/Hög assertion.
- `python3 .../skill-creator/scripts/quick_validate.py plugins/sol-advisor/skills/orchestration` — `Skill is valid!`
- `git diff --check` — passed.
- Fresh Sol review — `ship`, no findings.