### PR TITLE
docs: document Python 3.11+ requirement for verifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,3 +81,6 @@ cd /absolute/path/to/sol-advisor
 codex plugin marketplace add /absolute/path/to/sol-advisor
 codex plugin add sol-advisor@sol-advisor
 ~~~
+
+Running `plugins/sol-advisor/scripts/verify.sh` for maintainer verification requires
+Python 3.11+ because it uses the standard-library `tomllib` module.


### PR DESCRIPTION
## What changed

Document that running `plugins/sol-advisor/scripts/verify.sh` requires Python 3.11+ because the verifier uses `tomllib`.

## Why

This addresses the maintainer-verification documentation gap reported in #1 without changing runtime requirements, routing behavior, or agent configuration.

Python remains a maintainer/local-verification dependency only.

## Validation

Documentation-only change. The existing runtime and orchestration files are unchanged.

Closes the Python-version documentation portion of #1.