### PR TITLE
Fix primary runtime inspection without confirmation prompts

### DIFF
--- a/plugins/sol-advisor/scripts/inspect-agent-runtime.sh
+++ b/plugins/sol-advisor/scripts/inspect-agent-runtime.sh
@@ -1,16 +1,19 @@
 #!/bin/sh
-# Emit only allowlisted routing metadata from one exact native subagent rollout.
+# Emit only allowlisted routing metadata from one exact Codex rollout.
 
 set -eu
 
 usage() {
   cat <<'EOF'
-Usage: inspect-agent-runtime.sh [--sessions-dir DIR] THREAD_ID
+Usage: inspect-agent-runtime.sh [--primary] [--sessions-dir DIR] THREAD_ID
 
 Read the one rollout file whose filename ends with THREAD_ID and emit a compact JSON
 object containing only safe routing metadata. Without --sessions-dir, the sessions
 root is "$CODEX_HOME/sessions" when CODEX_HOME is already set, otherwise
 "$HOME/.codex/sessions".
+
+With --primary, inspect the latest turn of a primary session and require exact
+gpt-5.6-sol with high effort.
 EOF
 }
 
@@ -20,24 +23,36 @@ fail() {
 }
 
 sessions_dir=''
-case "$#" in
-  1)
-    thread_id=$1
-    ;;
-  3)
-    [ "$1" = "--sessions-dir" ] || {
+primary=false
+thread_id=''
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --sessions-dir)
+      [ "$#" -ge 2 ] || fail "--sessions-dir requires a directory."
+      [ -n "$2" ] || fail "--sessions-dir requires a non-empty directory."
+      sessions_dir=$2
+      shift 2
+      ;;
+    --primary)
+      primary=true
+      shift
+      ;;
+    -*)
       usage >&2
       exit 2
-    }
-    [ -n "$2" ] || fail "--sessions-dir requires a non-empty directory."
-    sessions_dir=$2
-    thread_id=$3
-    ;;
-  *)
-    usage >&2
-    exit 2
-    ;;
-esac
+      ;;
+    *)
+      [ -z "$thread_id" ] || fail "only one THREAD_ID is allowed."
+      thread_id=$1
+      shift
+      ;;
+  esac
+done
+
+[ -n "$thread_id" ] || {
+  usage >&2
+  exit 2
+}
 
 if ! printf '%s\n' "$thread_id" | LC_ALL=C grep -Eq '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'; then
   fail "THREAD_ID must be a lowercase UUID."
@@ -93,6 +108,66 @@ esac
 
 IFS= read -r rollout_file < "$matches_file" || fail "could not read the matched rollout filename."
 [ -f "$rollout_file" ] || fail "matched rollout is unavailable."
+
+# Primary sessions omit auxiliary-only role metadata. Read the latest turn so an
+# in-thread model change supersedes older evidence. Emit only five allowlisted fields.
+if [ "$primary" = true ]; then
+  if ! primary_output=$(jq -ce -s --arg expected_thread_id "$thread_id" '
+    def string_or_null:
+      if type == "string" then . else null end;
+
+    [ .[] | select(.type == "session_meta") | .payload ] as $sessions |
+    [ .[] | select(.type == "turn_context") | .payload ] as $turns |
+    if ($sessions | length) != 1 then
+      error("missing or ambiguous session metadata")
+    elif ($turns | length) == 0 then
+      error("missing turn context")
+    else
+      $sessions[0] as $session |
+      $turns[-1] as $latest |
+      ($session.id? | string_or_null) as $session_thread_id |
+      ($session.agent_role? | string_or_null) as $agent_role |
+      ($latest.model? | string_or_null) as $model |
+      ($latest.effort? | string_or_null) as $effort |
+      (($latest.model_provider? // $session.model_provider?) | string_or_null) as $model_provider |
+      ($latest.cwd? | string_or_null) as $cwd |
+      if $session_thread_id == null or $session_thread_id != $expected_thread_id then
+        error("session metadata does not identify the requested thread")
+      elif $agent_role != null and $agent_role != "" then
+        error("session metadata identifies an auxiliary role")
+      elif $model == null or $model == "" then
+        error("missing model")
+      elif $effort == null or $effort == "" then
+        error("missing effort")
+      elif $model_provider == null or $model_provider == "" then
+        error("missing model provider")
+      elif $cwd == null or $cwd == "" then
+        error("missing working directory")
+      else
+        {
+          thread_id: $session_thread_id,
+          model: $model,
+          effort: $effort,
+          model_provider: $model_provider,
+          cwd: $cwd
+        }
+      end
+    end
+  ' "$rollout_file" 2>/dev/null); then
+    fail "primary rollout metadata is missing, ambiguous, invalid, or incomplete."
+  fi
+
+  primary_model=$(printf '%s\n' "$primary_output" | jq -r '.model')
+  primary_effort=$(printf '%s\n' "$primary_output" | jq -r '.effort')
+  case "$primary_model:$primary_effort" in
+    *[!A-Za-z0-9._:-]*) fail "primary model or effort contains unsupported characters." ;;
+  esac
+  if [ "$primary_model" != gpt-5.6-sol ] || [ "$primary_effort" != high ]; then
+    fail "primary runtime mismatch: expected model=gpt-5.6-sol effort=high; observed model=$primary_model effort=$primary_effort."
+  fi
+  printf '%s\n' "$primary_output"
+  exit 0
+fi
 
 # The jq program reads only the matched JSONL and constructs a new allowlisted object.
 # It rejects absent or conflicting required routing values instead of inferring them.

--- a/plugins/sol-advisor/scripts/inspect-agent-runtime.sh
+++ b/plugins/sol-advisor/scripts/inspect-agent-runtime.sh
@@ -110,11 +110,13 @@ IFS= read -r rollout_file < "$matches_file" || fail "could not read the matched 
 [ -f "$rollout_file" ] || fail "matched rollout is unavailable."
 
 # Primary sessions omit auxiliary-only role metadata. Read the latest turn so an
-# in-thread model change supersedes older evidence. Emit only five allowlisted fields.
+# in-thread model change supersedes older evidence. Emit only six allowlisted fields.
 if [ "$primary" = true ]; then
   if ! primary_output=$(jq -ce -s --arg expected_thread_id "$thread_id" '
     def string_or_null:
       if type == "string" then . else null end;
+    def lowercase_uuid:
+      type == "string" and test("^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$");
 
     [ .[] | select(.type == "session_meta") | .payload ] as $sessions |
     [ .[] | select(.type == "turn_context") | .payload ] as $turns |
@@ -127,6 +129,7 @@ if [ "$primary" = true ]; then
       $turns[-1] as $latest |
       ($session.id? | string_or_null) as $session_thread_id |
       ($session.agent_role? | string_or_null) as $agent_role |
+      ($latest.turn_id? | string_or_null) as $turn_id |
       ($latest.model? | string_or_null) as $model |
       ($latest.effort? | string_or_null) as $effort |
       (($latest.model_provider? // $session.model_provider?) | string_or_null) as $model_provider |
@@ -135,6 +138,8 @@ if [ "$primary" = true ]; then
         error("session metadata does not identify the requested thread")
       elif $agent_role != null and $agent_role != "" then
         error("session metadata identifies an auxiliary role")
+      elif ($turn_id | lowercase_uuid | not) then
+        error("missing or invalid current turn id")
       elif $model == null or $model == "" then
         error("missing model")
       elif $effort == null or $effort == "" then
@@ -146,6 +151,7 @@ if [ "$primary" = true ]; then
       else
         {
           thread_id: $session_thread_id,
+          turn_id: $turn_id,
           model: $model,
           effort: $effort,
           model_provider: $model_provider,

--- a/plugins/sol-advisor/scripts/verify.sh
+++ b/plugins/sol-advisor/scripts/verify.sh
@@ -387,6 +387,55 @@ zero_id=22222222-2222-7222-8222-222222222222
 if sh "$runtime_inspector" --sessions-dir "$runtime_sessions" "$zero_id" >/dev/null 2>&1; then fail "runtime inspector accepted zero matches"; fi
 pass "runtime inspector Luna/Max routing and safe refusal"
 
+primary_sessions=$tmp_dir/primary-runtime-sessions
+primary_day=$primary_sessions/2026/08/16
+mkdir -p "$primary_day"
+primary_id=33333333-3333-7333-8333-333333333333
+primary_rollout=$primary_day/rollout-2026-08-16T00-00-00-$primary_id.jsonl
+printf '%s\n' \
+  '{"type":"response_item","payload":{"prompt":"PRIMARY_PROMPT_MUST_NOT_LEAK","transcript":"TRANSCRIPT_MUST_NOT_LEAK"}}' \
+  "{\"type\":\"session_meta\",\"payload\":{\"id\":\"$primary_id\",\"parent_thread_id\":\"00000000-0000-7000-8000-000000000000\",\"model_provider\":\"openai\",\"cwd\":\"/old-cwd\"}}" \
+  '{"type":"turn_context","payload":{"model":"gpt-5.6-terra","effort":"medium","cwd":"/old-cwd"}}' \
+  '{"type":"turn_context","payload":{"model":"gpt-5.6-sol","effort":"high","cwd":"/current-cwd"}}' \
+  > "$primary_rollout"
+primary_output=$(sh "$runtime_inspector" --primary --sessions-dir "$primary_sessions" "$primary_id")
+printf '%s\n' "$primary_output" | jq -e --arg id "$primary_id" '
+  keys == ["cwd", "effort", "model", "model_provider", "thread_id"]
+  and .thread_id == $id and .model == "gpt-5.6-sol" and .effort == "high"
+  and .model_provider == "openai" and .cwd == "/current-cwd"
+' >/dev/null || fail "primary inspector returned wrong latest-turn evidence"
+if printf '%s\n' "$primary_output" | grep -Eq 'PRIMARY_PROMPT|TRANSCRIPT|old-cwd|agent_role|agent_path'; then
+  fail "primary inspector leaked non-allowlisted or historical payload"
+fi
+
+primary_mismatch_id=44444444-4444-7444-8444-444444444444
+printf '%s\n' \
+  "{\"type\":\"session_meta\",\"payload\":{\"id\":\"$primary_mismatch_id\",\"model_provider\":\"openai\",\"cwd\":\"/fixture\"}}" \
+  '{"type":"turn_context","payload":{"model":"gpt-5.6-terra","effort":"high","cwd":"/fixture"}}' \
+  > "$primary_day/rollout-2026-08-16T00-00-01-$primary_mismatch_id.jsonl"
+if sh "$runtime_inspector" --primary --sessions-dir "$primary_sessions" "$primary_mismatch_id" >/dev/null 2>&1; then
+  fail "primary inspector accepted a model mismatch"
+fi
+
+primary_aux_id=55555555-5555-7555-8555-555555555555
+printf '%s\n' \
+  "{\"type\":\"session_meta\",\"payload\":{\"id\":\"$primary_aux_id\",\"agent_role\":\"sol_advisor_sol_reviewer\",\"model_provider\":\"openai\",\"cwd\":\"/fixture\"}}" \
+  '{"type":"turn_context","payload":{"model":"gpt-5.6-sol","effort":"high","cwd":"/fixture"}}' \
+  > "$primary_day/rollout-2026-08-16T00-00-02-$primary_aux_id.jsonl"
+if sh "$runtime_inspector" --primary --sessions-dir "$primary_sessions" "$primary_aux_id" >/dev/null 2>&1; then
+  fail "primary inspector accepted an auxiliary role"
+fi
+
+primary_missing_id=66666666-6666-7666-8666-666666666666
+printf '%s\n' \
+  "{\"type\":\"session_meta\",\"payload\":{\"id\":\"$primary_missing_id\",\"model_provider\":\"openai\",\"cwd\":\"/fixture\"}}" \
+  '{"type":"turn_context","payload":{"model":"gpt-5.6-sol","cwd":"/fixture"}}' \
+  > "$primary_day/rollout-2026-08-16T00-00-03-$primary_missing_id.jsonl"
+if sh "$runtime_inspector" --primary --sessions-dir "$primary_sessions" "$primary_missing_id" >/dev/null 2>&1; then
+  fail "primary inspector accepted missing effort"
+fi
+pass "primary inspector uses latest-turn evidence and fails closed"
+
 for document in "$contracts" "$operations"; do
   grep -Fq 'agent_type: sol_advisor_luna_implementer' "$document" || fail "missing Luna spawn in $document"
   grep -Fq 'agent_type: sol_advisor_terra_implementer' "$document" || fail "missing Terra spawn in $document"
@@ -405,6 +454,9 @@ grep -Fq 'Solo is the default' "$skill" || fail "skill omits solo default"
 grep -Fq 'One auxiliary agent is the default maximum' "$skill" || fail "skill omits auxiliary limit"
 grep -Fq 'A later declaration may only escalate the route when newly' "$skill" || fail "skill omits escalation gate"
 grep -Fq 'never silently downgrade' "$skill" || fail "skill permits silent downgrade"
+grep -Fq -- '--primary "$CODEX_THREAD_ID"' "$skill" || fail "skill omits exact primary runtime inspection"
+grep -Fq 'pending local inspection' "$skill" || fail "skill omits pre-inspection route disclosure"
+grep -Fq 'manual attestation' "$skill" || fail "skill permits unverified primary attestation"
 grep -Fqi 'public metadata' "$skill" || fail "skill lacks public-metadata evidence rule"
 grep -Fqi 'local inspector' "$skill" || fail "skill lacks runtime fallback rule"
 grep -Fqi 'parent captures and verifies exact before-and-after' "$contracts" || fail "contracts lack behavioral read-only state check"

--- a/plugins/sol-advisor/scripts/verify.sh
+++ b/plugins/sol-advisor/scripts/verify.sh
@@ -391,17 +391,20 @@ primary_sessions=$tmp_dir/primary-runtime-sessions
 primary_day=$primary_sessions/2026/08/16
 mkdir -p "$primary_day"
 primary_id=33333333-3333-7333-8333-333333333333
+primary_old_turn_id=bbbbbbbb-bbbb-7bbb-8bbb-bbbbbbbbbbbb
+primary_current_turn_id=cccccccc-cccc-7ccc-8ccc-cccccccccccc
 primary_rollout=$primary_day/rollout-2026-08-16T00-00-00-$primary_id.jsonl
 printf '%s\n' \
   '{"type":"response_item","payload":{"prompt":"PRIMARY_PROMPT_MUST_NOT_LEAK","transcript":"TRANSCRIPT_MUST_NOT_LEAK"}}' \
   "{\"type\":\"session_meta\",\"payload\":{\"id\":\"$primary_id\",\"parent_thread_id\":\"00000000-0000-7000-8000-000000000000\",\"model_provider\":\"openai\",\"cwd\":\"/old-cwd\"}}" \
-  '{"type":"turn_context","payload":{"model":"gpt-5.6-terra","effort":"medium","cwd":"/old-cwd"}}' \
-  '{"type":"turn_context","payload":{"model":"gpt-5.6-sol","effort":"high","cwd":"/current-cwd"}}' \
+  "{\"type\":\"turn_context\",\"payload\":{\"turn_id\":\"$primary_old_turn_id\",\"model\":\"gpt-5.6-terra\",\"effort\":\"medium\",\"cwd\":\"/old-cwd\"}}" \
+  "{\"type\":\"turn_context\",\"payload\":{\"turn_id\":\"$primary_current_turn_id\",\"model\":\"gpt-5.6-sol\",\"effort\":\"high\",\"cwd\":\"/current-cwd\"}}" \
   > "$primary_rollout"
 primary_output=$(sh "$runtime_inspector" --primary --sessions-dir "$primary_sessions" "$primary_id")
-printf '%s\n' "$primary_output" | jq -e --arg id "$primary_id" '
-  keys == ["cwd", "effort", "model", "model_provider", "thread_id"]
-  and .thread_id == $id and .model == "gpt-5.6-sol" and .effort == "high"
+printf '%s\n' "$primary_output" | jq -e --arg id "$primary_id" --arg turn_id "$primary_current_turn_id" '
+  keys == ["cwd", "effort", "model", "model_provider", "thread_id", "turn_id"]
+  and .thread_id == $id and .turn_id == $turn_id
+  and .model == "gpt-5.6-sol" and .effort == "high"
   and .model_provider == "openai" and .cwd == "/current-cwd"
 ' >/dev/null || fail "primary inspector returned wrong latest-turn evidence"
 if printf '%s\n' "$primary_output" | grep -Eq 'PRIMARY_PROMPT|TRANSCRIPT|old-cwd|agent_role|agent_path'; then
@@ -409,32 +412,43 @@ if printf '%s\n' "$primary_output" | grep -Eq 'PRIMARY_PROMPT|TRANSCRIPT|old-cwd
 fi
 
 primary_mismatch_id=44444444-4444-7444-8444-444444444444
+primary_mismatch_turn_id=dddddddd-dddd-7ddd-8ddd-dddddddddddd
 printf '%s\n' \
   "{\"type\":\"session_meta\",\"payload\":{\"id\":\"$primary_mismatch_id\",\"model_provider\":\"openai\",\"cwd\":\"/fixture\"}}" \
-  '{"type":"turn_context","payload":{"model":"gpt-5.6-terra","effort":"high","cwd":"/fixture"}}' \
+  "{\"type\":\"turn_context\",\"payload\":{\"turn_id\":\"$primary_mismatch_turn_id\",\"model\":\"gpt-5.6-terra\",\"effort\":\"high\",\"cwd\":\"/fixture\"}}" \
   > "$primary_day/rollout-2026-08-16T00-00-01-$primary_mismatch_id.jsonl"
 if sh "$runtime_inspector" --primary --sessions-dir "$primary_sessions" "$primary_mismatch_id" >/dev/null 2>&1; then
   fail "primary inspector accepted a model mismatch"
 fi
 
 primary_aux_id=55555555-5555-7555-8555-555555555555
+primary_aux_turn_id=eeeeeeee-eeee-7eee-8eee-eeeeeeeeeeee
 printf '%s\n' \
   "{\"type\":\"session_meta\",\"payload\":{\"id\":\"$primary_aux_id\",\"agent_role\":\"sol_advisor_sol_reviewer\",\"model_provider\":\"openai\",\"cwd\":\"/fixture\"}}" \
-  '{"type":"turn_context","payload":{"model":"gpt-5.6-sol","effort":"high","cwd":"/fixture"}}' \
+  "{\"type\":\"turn_context\",\"payload\":{\"turn_id\":\"$primary_aux_turn_id\",\"model\":\"gpt-5.6-sol\",\"effort\":\"high\",\"cwd\":\"/fixture\"}}" \
   > "$primary_day/rollout-2026-08-16T00-00-02-$primary_aux_id.jsonl"
 if sh "$runtime_inspector" --primary --sessions-dir "$primary_sessions" "$primary_aux_id" >/dev/null 2>&1; then
   fail "primary inspector accepted an auxiliary role"
 fi
 
 primary_missing_id=66666666-6666-7666-8666-666666666666
+primary_missing_turn_id=ffffffff-ffff-7fff-8fff-ffffffffffff
 printf '%s\n' \
   "{\"type\":\"session_meta\",\"payload\":{\"id\":\"$primary_missing_id\",\"model_provider\":\"openai\",\"cwd\":\"/fixture\"}}" \
-  '{"type":"turn_context","payload":{"model":"gpt-5.6-sol","cwd":"/fixture"}}' \
+  "{\"type\":\"turn_context\",\"payload\":{\"turn_id\":\"$primary_missing_turn_id\",\"model\":\"gpt-5.6-sol\",\"cwd\":\"/fixture\"}}" \
   > "$primary_day/rollout-2026-08-16T00-00-03-$primary_missing_id.jsonl"
 if sh "$runtime_inspector" --primary --sessions-dir "$primary_sessions" "$primary_missing_id" >/dev/null 2>&1; then
   fail "primary inspector accepted missing effort"
 fi
-pass "primary inspector uses latest-turn evidence and fails closed"
+primary_invalid_turn_id=77777777-7777-7777-8777-777777777777
+printf '%s\n' \
+  "{\"type\":\"session_meta\",\"payload\":{\"id\":\"$primary_invalid_turn_id\",\"model_provider\":\"openai\",\"cwd\":\"/fixture\"}}" \
+  '{"type":"turn_context","payload":{"turn_id":"not-a-uuid","model":"gpt-5.6-sol","effort":"high","cwd":"/fixture"}}' \
+  > "$primary_day/rollout-2026-08-16T00-00-04-$primary_invalid_turn_id.jsonl"
+if sh "$runtime_inspector" --primary --sessions-dir "$primary_sessions" "$primary_invalid_turn_id" >/dev/null 2>&1; then
+  fail "primary inspector accepted an invalid current turn id"
+fi
+pass "primary inspector uses identified latest-turn evidence and fails closed"
 
 for document in "$contracts" "$operations"; do
   grep -Fq 'agent_type: sol_advisor_luna_implementer' "$document" || fail "missing Luna spawn in $document"

--- a/plugins/sol-advisor/skills/orchestration/SKILL.md
+++ b/plugins/sol-advisor/skills/orchestration/SKILL.md
@@ -15,13 +15,24 @@ Read [references/role-contracts.md](references/role-contracts.md) before the fir
 delegation. Use [references/operations.md](references/operations.md) for exact spawn,
 preflight, runtime-evidence, isolation, and maintainer procedures.
 
-## Confirm the primary session
+## Verify the primary session
 
-Run the primary Codex session on gpt-5.6-sol with high reasoning. Verify the current
-model and effort when runtime metadata exposes them. If either differs, tell the user
-to select Sol / High and stop before delegation. If runtime metadata does not expose
-them, ask the user to confirm Sol / High and stop until confirmed. A skill cannot
-change the primary model itself; never assume or claim this prerequisite is satisfied.
+Run the primary Codex session on gpt-5.6-sol with high reasoning. Use complete
+host-provided runtime metadata when it exposes both fields for the current session. If
+either field is unavailable, emit the route declaration below before using task tools,
+then inspect the exact current rollout:
+
+~~~sh
+skill_dir=<directory-containing-this-SKILL.md>
+runtime_inspector="$skill_dir/../../scripts/inspect-agent-runtime.sh"
+sh "$runtime_inspector" --primary "$CODEX_THREAD_ID"
+~~~
+
+Continue without prompting when the result verifies exact Sol / High. If the current
+thread ID is unavailable, inspection fails, or either field differs, stop and tell the
+user to select Sol / High before retrying. Do not accept configured defaults, previous
+threads, auxiliary metadata, or manual attestation as active-session evidence. A skill
+cannot change the primary model itself.
 
 ## Declare the route before task tools
 
@@ -38,15 +49,18 @@ justifies another mode. A later declaration may only escalate the route when new
 observed risk justifies it; never silently downgrade. Record the evidence for an
 escalation. Details and the task-scoped preflight matrix are in operations.md.
 
+No local primary-runtime inspection may precede this declaration. When host metadata
+is incomplete, state in `risk` that primary evidence is pending local inspection.
+
 ## Preflight selected auxiliaries only
 
-Confirm Sol / High in the primary session. Preflight only an auxiliary selected by the
-declared route: none for solo; Luna / Max or Terra / High for delegate; fresh Sol / High
-for audit; and the selected implementer plus fresh Sol reviewer for full. Public metadata
-for role, model, and effort is authoritative. If it omits a model or effort, use the
-local inspector only for that omitted field. Missing, conflicting, unavailable, or
-unobservable evidence stops the affected lane; never silently substitute a role,
-model, effort, or reviewer.
+Verify Sol / High in the primary session as described above. Preflight only an
+auxiliary selected by the declared route: none for solo; Luna / Max or Terra / High for
+delegate; fresh Sol / High for audit; and the selected implementer plus fresh Sol
+reviewer for full. Public metadata for the selected auxiliary's role, model, and effort
+is authoritative. If it omits a model or effort, use the local inspector only for that
+omitted field. Missing, conflicting, unavailable, or unobservable evidence stops the
+affected lane; never silently substitute a role, model, effort, or reviewer.
 
 ## Route delivery without duplication
 

--- a/plugins/sol-advisor/skills/orchestration/SKILL.md
+++ b/plugins/sol-advisor/skills/orchestration/SKILL.md
@@ -28,6 +28,9 @@ runtime_inspector="$skill_dir/../../scripts/inspect-agent-runtime.sh"
 sh "$runtime_inspector" --primary "$CODEX_THREAD_ID"
 ~~~
 
+The inspector reports the latest applied `turn_id`; a UI change made during a running
+turn becomes runtime evidence only after Codex starts and records the next turn.
+
 Continue without prompting when the result verifies exact Sol / High. If the current
 thread ID is unavailable, inspection fails, or either field differs, stop and tell the
 user to select Sol / High before retrying. Do not accept configured defaults, previous

--- a/plugins/sol-advisor/skills/orchestration/references/operations.md
+++ b/plugins/sol-advisor/skills/orchestration/references/operations.md
@@ -40,8 +40,9 @@ unobservable role/model/effort is a hard stop; never substitute another role.
 
 ## Selective route declaration, preflight, and caching
 
-The primary session must be Sol / High. Companion installation is separate from task
-routing because plugin installation does not register user-owned TOMLs.
+The primary session must be Sol / High. Verify the active session rather than inferring
+it from configured defaults. Companion installation is separate from task routing
+because plugin installation does not register user-owned TOMLs.
 
 At installation or update time, run the repository-relative installer and its exactness
 check:
@@ -78,6 +79,10 @@ or high-risk exception. The root may emit a later declaration only to escalate w
 newly observed risk justifies it. It records that evidence and never silently
 downgrades.
 
+A local primary-runtime inspection also requires this declaration first. When complete
+host metadata is unavailable, state in the initial `risk` that primary evidence is
+pending local inspection.
+
 The existing --check flag verifies all three roles. For task-scoped preflight, check
 only the auxiliaries selected by the declaration; every check is non-mutating and
 fail-closed:
@@ -111,8 +116,42 @@ for Terra.
 
 If public metadata omits model or effort, use the local inspector below as a fallback
 for those omitted fields only. Do not use it to replace available public evidence.
+This rule applies to auxiliary evidence; primary evidence follows the next section.
 
 ## Runtime routing evidence
+
+### Primary-session evidence
+
+Use complete host-provided runtime metadata when it identifies both the active model
+and effort for the current primary session. If either field is unavailable, resolve
+the helper relative to the installed skill and inspect the exact current thread after
+the route declaration:
+
+~~~sh
+skill_dir=<directory-containing-this-SKILL.md>
+runtime_inspector="$skill_dir/../../scripts/inspect-agent-runtime.sh"
+sh "$runtime_inspector" --primary "$CODEX_THREAD_ID"
+~~~
+
+For a disposable fixture or non-default session root:
+
+~~~sh
+sh "$runtime_inspector" --primary --sessions-dir /absolute/path/to/sessions <primary-thread-id>
+~~~
+
+Primary mode accepts sessions without auxiliary-only `agent_role` metadata and rejects
+sessions that identify an auxiliary role. It reads the latest `turn_context`, emits
+only the thread ID, model, effort, provider, and working directory, and accepts exact
+`gpt-5.6-sol` / `high` only. Invalid IDs, zero or multiple rollout matches, missing or
+malformed fields, auxiliary roles, and model or effort mismatches fail closed. It does
+not expose prompts, messages, environment variables, tokens, configuration, or
+arbitrary rollout payloads.
+
+If host metadata and local inspection cannot verify the requirement, stop. Configured
+defaults, previous threads, auxiliary metadata, and manual attestation do not prove
+the active primary session.
+
+### Auxiliary routing evidence
 
 The public spawn/details record is authoritative for the selected role and any exposed
 model/effort. When model or effort is omitted, resolve the helper relative to the

--- a/plugins/sol-advisor/skills/orchestration/references/operations.md
+++ b/plugins/sol-advisor/skills/orchestration/references/operations.md
@@ -141,11 +141,12 @@ sh "$runtime_inspector" --primary --sessions-dir /absolute/path/to/sessions <pri
 
 Primary mode accepts sessions without auxiliary-only `agent_role` metadata and rejects
 sessions that identify an auxiliary role. It reads the latest `turn_context`, emits
-only the thread ID, model, effort, provider, and working directory, and accepts exact
-`gpt-5.6-sol` / `high` only. Invalid IDs, zero or multiple rollout matches, missing or
-malformed fields, auxiliary roles, and model or effort mismatches fail closed. It does
-not expose prompts, messages, environment variables, tokens, configuration, or
-arbitrary rollout payloads.
+only the thread ID, applied turn ID, model, effort, provider, and working directory,
+and accepts exact `gpt-5.6-sol` / `high` only. The turn ID must be a lowercase UUID. A
+UI change made during a running turn applies only after Codex starts and records the
+next turn. Invalid IDs, zero or multiple rollout matches, missing or malformed fields,
+auxiliary roles, and model or effort mismatches fail closed. It does not expose prompts,
+messages, environment variables, tokens, configuration, or arbitrary rollout payloads.
 
 If host metadata and local inspection cannot verify the requirement, stop. Configured
 defaults, previous threads, auxiliary metadata, and manual attestation do not prove

--- a/plugins/sol-advisor/skills/orchestration/references/role-contracts.md
+++ b/plugins/sol-advisor/skills/orchestration/references/role-contracts.md
@@ -21,11 +21,12 @@ Solo is the default; one auxiliary is the default maximum. Full is an explicit b
 or high-risk exception. A later route declaration may only escalate after newly
 observed risk justifies it and supplies that evidence; never silently downgrade.
 
-Confirm Sol / High in the primary session, then preflight only auxiliaries selected by
-the route: none for solo; Luna / Max or Terra / High for delegate; fresh Sol / High
-for audit; and one selected implementer plus fresh Sol reviewer for full. Cache each
-successful check only for the task. After spawning, complete the selected role's
-routing and reviewer-isolation checks before accepting the result:
+Verify Sol / High through the exact primary-session evidence path in `SKILL.md`, then
+preflight only auxiliaries selected by the route: none for solo; Luna / Max or Terra /
+High for delegate; fresh Sol / High for audit; and one selected implementer plus fresh
+Sol reviewer for full. Cache each successful check only for the task. After spawning,
+complete the selected role's routing and reviewer-isolation checks before accepting
+the result:
 
 1. Require the selected exact native role and fresh-context spawn contract.
 2. Observe the selected role, model, and effort through public spawn/details metadata


### PR DESCRIPTION
## Summary

- Add a focused `--primary` mode that inspects the exact current rollout through `CODEX_THREAD_ID`.
- Read the latest `turn_context`, require and emit its lowercase-UUID `turn_id`, and use that identified turn's model and effort as the applied runtime evidence.
- Require exact `gpt-5.6-sol` / `high` evidence while preserving the existing auxiliary inspector contract and fail-closed behavior.
- Explain that a reasoning-level change made in the UI during a running turn becomes runtime evidence only after Codex starts and records the next turn.
- Replace repeated manual confirmation with automatic primary-session evidence.

## Why

Sol Advisor 0.6.0 falls back to asking the user for Sol / High confirmation when host metadata is not exposed, even though Codex records the applied model and effort in each thread rollout. The existing auxiliary runtime inspector rejects primary sessions because they do not contain auxiliary-only `agent_role` metadata.

A live reproduction also showed an important turn boundary: selecting High in the UI while a Medium turn is already running does not retroactively change that turn. The rollout continues to report Medium until the next turn starts. Returning the validated latest `turn_id` makes the inspected model and effort attributable to one applied turn instead of to the task in general.

This PR isolates the root-session runtime inspection fix for #25. The advisory hook and configuration UX proposed in #26 can be evaluated independently.

## Verification

- `sh plugins/sol-advisor/scripts/verify.sh`
- `git diff --check`
- Medium-to-High fixture selects the latest turn and returns its exact `turn_id` with `effort: high`.
- Missing or malformed current-turn IDs, missing effort, model mismatch, and auxiliary-role evidence fail closed.
- Prompt, transcript, historical working directory, and auxiliary-only fields remain outside the primary output allowlist.

Fixes #25
